### PR TITLE
Prepare release v0.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 3
 
 [[package]]
 name = "redis-zero-protocol-parser"
-version = "0.3.0"
+version = "0.3.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "redis-zero-protocol-parser"
 repository = "https://github.com/crodas/redis-protocol-parser"
 description = "Redis Protocol Parser. A zero copy stream-friendly parser"
 license = "BSD-3-Clause"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Cesar Rodas <cesar@rodasm.com.py>"]
 edition = "2018"
 


### PR DESCRIPTION
Prepares the release for v0.3.1 which fixes the bug #7 introduced in the
last release.